### PR TITLE
Add python_ex that returns python values.

### DIFF
--- a/inline-python-macros/Cargo.toml
+++ b/inline-python-macros/Cargo.toml
@@ -14,3 +14,6 @@ proc_macro = true
 proc-macro2 = { version = "0.4", features = ["span-locations"] }
 quote = "0.6"
 syn = { version = "0.15", features = ["parsing"] }
+
+[dev-dependencies]
+inline-python = { version = "0.1", path = "../inline-python" }

--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -7,11 +7,12 @@ use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 use quote::quote;
 use std::fmt::Write;
 use std::collections::BTreeSet;
+use syn::parse_macro_input;
 
 #[proc_macro]
 pub fn python(input: TokenStream1) -> TokenStream1 {
 	let mut x = EmbedPython {
-		python: String::new(),
+		code: String::new(),
 		variables: TokenStream::new(),
 		variable_names: BTreeSet::new(),
 		line: 0,
@@ -21,15 +22,15 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 	x.add(TokenStream::from(input));
 
 	let EmbedPython {
-		python, variables, ..
+		code, variables, ..
 	} = x;
 
-	let q = quote! {
+	TokenStream1::from(quote! {
 		{
 			let _python_lock = ::inline_python::pyo3::Python::acquire_gil();
 			let mut _python_variables = ::inline_python::pyo3::types::PyDict::new(_python_lock.python());
 			#variables
-			match _python_lock.python().run(#python, None, Some(_python_variables)) {
+			match _python_lock.python().run(#code, None, Some(_python_variables)) {
 				Ok(_) => (),
 				Err(e) => {
 					e.print(_python_lock.python());
@@ -37,13 +38,56 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 				}
 			}
 		}
+	})
+}
+
+struct PythonExArgs {
+	pub python: syn::Expr,
+	pub comma: syn::token::Comma,
+	pub code: TokenStream,
+}
+
+impl syn::parse::Parse for PythonExArgs {
+	fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+		Ok(Self {
+			python: input.parse()?,
+			comma: input.parse()?,
+			code: input.parse()?,
+		})
+	}
+}
+
+#[proc_macro]
+pub fn python_ex(input: TokenStream1) -> TokenStream1 {
+	let PythonExArgs {
+		python, code, ..
+	} =  parse_macro_input!(input as PythonExArgs);
+
+	let mut x = EmbedPython {
+		code: String::new(),
+		variables: TokenStream::new(),
+		variable_names: BTreeSet::new(),
+		line: 0,
+		indent: None,
 	};
 
-	q.into()
+	x.add(code);
+
+	let EmbedPython {
+		code, variables, ..
+	} = x;
+
+	TokenStream1::from(quote! {
+		{
+			let mut _python_variables = ::inline_python::pyo3::types::PyDict::new(#python);
+			#variables
+			#python.run(#code, None, Some(_python_variables))
+		}
+	})
 }
 
 struct EmbedPython {
-	python: String,
+	code: String,
 	variables: TokenStream,
 	variable_names: BTreeSet<String>,
 	line: usize,
@@ -58,10 +102,10 @@ impl EmbedPython {
 			let loc = token.span().start();
 
 			if loc.line != self.line {
-				self.python.push('\n');
+				self.code.push('\n');
 				let indent = *self.indent.get_or_insert(loc.column);
 				for _ in 0..(loc.column.saturating_sub(indent)) {
-					self.python.push(' ');
+					self.code.push(' ');
 				}
 				self.line = loc.line;
 			}
@@ -74,9 +118,9 @@ impl EmbedPython {
 						Delimiter::Bracket => ('[', ']'),
 						Delimiter::None => (' ', ' '),
 					};
-					self.python.push(start);
+					self.code.push(start);
 					self.add(x.stream());
-					self.python.push(end);
+					self.code.push(end);
 				}
 				TokenTree::Punct(x) => {
 					if x.as_char() == '\'' && x.spacing() == Spacing::Joint {
@@ -92,17 +136,17 @@ impl EmbedPython {
 									.expect("Unable to convert variable to Python");
 							});
 						}
-						self.python.push_str(&pyname);
-						self.python.push(' ');
+						self.code.push_str(&pyname);
+						self.code.push(' ');
 					} else {
-						self.python.push(x.as_char());
+						self.code.push(x.as_char());
 						if x.spacing() == Spacing::Alone {
-							self.python.push(' ');
+							self.code.push(' ');
 						}
 					}
 				}
-				TokenTree::Ident(x) => write!(&mut self.python, "{} ", x).unwrap(),
-				TokenTree::Literal(x) => write!(&mut self.python, "{} ", x).unwrap(),
+				TokenTree::Ident(x) => write!(&mut self.code, "{} ", x).unwrap(),
+				TokenTree::Literal(x) => write!(&mut self.code, "{} ", x).unwrap(),
 			}
 		}
 	}

--- a/inline-python/src/lib.rs
+++ b/inline-python/src/lib.rs
@@ -43,5 +43,5 @@
 //! Python code back into Rust. Support for that will be added in a later
 //! version of this crate.
 
-pub use inline_python_macros::python;
+pub use inline_python_macros::{python, python_ex};
 pub use pyo3;

--- a/inline-python/tests/python_ex.rs
+++ b/inline-python/tests/python_ex.rs
@@ -1,0 +1,14 @@
+#![feature(proc_macro_hygiene)]
+
+use inline_python::{pyo3, python_ex};
+
+use pyo3::prelude::FromPyObject;
+
+fn main() -> pyo3::PyResult<()> {
+	let gil    = pyo3::Python::acquire_gil();
+
+	let result = python_ex!(gil.python(), 1 + 1)?;
+	let result = u32::extract(result)?;
+	assert_eq!(result, 2);
+	Ok(())
+}

--- a/inline-python/tests/python_ex.rs
+++ b/inline-python/tests/python_ex.rs
@@ -2,11 +2,10 @@
 
 use inline_python::{pyo3, python_ex};
 
-use pyo3::prelude::FromPyObject;
+use pyo3::FromPyObject;
 
 fn main() -> pyo3::PyResult<()> {
 	let gil    = pyo3::Python::acquire_gil();
-
 	let result = python_ex!(gil.python(), 1 + 1)?;
 	let result = u32::extract(result)?;
 	assert_eq!(result, 2);


### PR DESCRIPTION
This PR adds a `python_ex` version that takes a `pyo3::Python` argument in addition to the python code. Doing so allows the generated code to return a `PyAny` (which borrows the `Python` object).

Still some bike-shedding opportunities whether this should be a separate macro or if it should be handle by some magic text at top of the code in the original `python` macro.