### PR TITLE
Compile python code at Rust compile time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+travis.yaml

--- a/inline-python-macros/Cargo.toml
+++ b/inline-python-macros/Cargo.toml
@@ -14,3 +14,4 @@ proc_macro = true
 proc-macro2 = { version = "0.4", features = ["span-locations"] }
 quote = "0.6"
 syn = { version = "0.15", features = ["parsing"] }
+pyo3 = "0.6"

--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -8,6 +8,10 @@ use proc_macro2::{Delimiter, LineColumn, Spacing, TokenStream, TokenTree};
 use quote::quote;
 use std::collections::BTreeSet;
 use std::fmt::Write;
+use std::ptr::NonNull;
+use std::os::raw::c_char;
+
+use pyo3::{ffi, AsPyPointer, PyErr, PyObject, Python};
 
 #[proc_macro]
 pub fn python(input: TokenStream1) -> TokenStream1 {
@@ -33,6 +37,21 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 	python.push('\0');
 	filename.push('\0');
 
+	let compiled = unsafe {
+		let gil = Python::acquire_gil();
+		let py  = gil.python();
+
+		let compiled_code = match NonNull::new(ffi::Py_CompileString(as_c_str(&python), as_c_str(&filename), ffi::Py_file_input)) {
+			None => panic!("{}", compile_error_msg(py)),
+			Some(x) => PyObject::from_owned_ptr(py, x.as_ptr()),
+		};
+
+		python_marshal_object_to_bytes(py, &compiled_code).expect("marshalling compiled python code failed")
+	};
+
+	let compiled = syn::LitByteStr::new(&compiled, proc_macro2::Span::call_site());
+
+
 	let q = quote! {
 		{
 			let _python_lock = ::inline_python::pyo3::Python::acquire_gil();
@@ -40,8 +59,7 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 			#variables
 			let r = ::inline_python::run_python_code(
 				_python_lock.python(),
-				unsafe { ::inline_python::CStr::from_bytes_with_nul_unchecked(#python.as_bytes()) },
-				unsafe { ::inline_python::CStr::from_bytes_with_nul_unchecked(#filename.as_bytes()) },
+				#compiled,
 				Some(_python_variables)
 			);
 			match r {
@@ -55,6 +73,91 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 	};
 
 	q.into()
+}
+
+unsafe fn as_c_str<T: AsRef<[u8]> + ?Sized>(value: &T) -> *const c_char {
+	std::ffi::CStr::from_bytes_with_nul_unchecked(value.as_ref()).as_ptr()
+}
+
+extern "C" {
+	fn PyMarshal_WriteObjectToString(object: *mut ffi::PyObject, version: std::os::raw::c_int) ->  *mut ffi::PyObject;
+}
+
+/// Use built-in python marshal support to turn an object into bytes.
+fn python_marshal_object_to_bytes(py: Python, object: &PyObject) -> pyo3::PyResult<Vec<u8>> {
+	unsafe {
+		let bytes = PyMarshal_WriteObjectToString(object.as_ptr(), 2);
+		if bytes.is_null() {
+			return Err(PyErr::fetch(py))
+		}
+
+		let mut buffer = std::ptr::null_mut();
+		let mut size  = 0isize;
+		ffi::PyBytes_AsStringAndSize(bytes, &mut buffer, &mut size);
+		let result = Vec::from(std::slice::from_raw_parts(buffer as *const u8, size as usize));
+
+		ffi::Py_DecRef(bytes);
+		Ok(result)
+	}
+}
+
+/// Convert a PyUnicode object to String.
+unsafe fn py_unicode_string(object: *mut ffi::PyObject) -> String {
+	let mut size = 0isize;
+	let data = ffi::PyUnicode_AsUTF8AndSize(object, &mut size) as *const u8;
+	let data = std::slice::from_raw_parts(data, size as usize);
+	let data = std::str::from_utf8_unchecked(data);
+	String::from(data)
+}
+
+/// Convert a python object to a string using the the python `str()` function.
+fn python_str(object: &PyObject) -> String {
+	unsafe {
+		let string = ffi::PyObject_Str(object.as_ptr());
+		let result = py_unicode_string(string);
+		ffi::Py_DecRef(string);
+		result
+	}
+}
+
+/// Get the object of a PyErrValue, if any.
+fn err_value_object(py: Python, value: pyo3::PyErrValue) -> Option<PyObject> {
+	match value {
+		pyo3::PyErrValue::None        => None,
+		pyo3::PyErrValue::Value(x)    => Some(x),
+		pyo3::PyErrValue::ToArgs(x)   => Some(x.arguments(py)),
+		pyo3::PyErrValue::ToObject(x) => Some(x.to_object(py)),
+	}
+}
+
+fn compile_error_msg(py: Python) -> String {
+	use pyo3::type_object::PyTypeObject;
+	use pyo3::AsPyRef;
+
+	if !PyErr::occurred(py) {
+		return String::from("failed to compile python code, but no detailed error is available");
+	}
+
+	let error = PyErr::fetch(py);
+
+	if error.matches(py, pyo3::exceptions::SyntaxError::type_object()) {
+		let PyErr { ptype: kind, pvalue: value, .. } = error;
+		let value = match err_value_object(py, value) {
+			None    => return kind.as_ref(py).name().into_owned(),
+			Some(x) => x,
+		};
+
+		return match value.extract::<(String, (String, i32, i32, String))>(py) {
+			Ok((msg, (file, line, col, _token))) => format!("{} at {}:{}:{}", msg, file, line, col),
+			Err(_) => python_str(&value),
+		};
+	}
+
+	let PyErr { ptype: kind, pvalue: value, .. } = error;
+	match err_value_object(py, value) {
+		None    => kind.as_ref(py).name().into_owned(),
+		Some(x) => python_str(&x),
+	}
 }
 
 struct EmbedPython {

--- a/travis.yaml
+++ b/travis.yaml
@@ -1,0 +1,6 @@
+language: rust
+rust:
+  - nightly
+dist: xenial
+before_install:
+  - sudo apt-get install -y libpython3-dev


### PR DESCRIPTION
This PR compiles the python code at Rust compile time. Implements #3.

Currently this will ouput this on a syntax error:
```
error: proc macro panicked
  --> inline-python-example/src/main.rs:7:2
   |
7  |       python! {
   |  _____^
8  | |         import matplotlib.pyplot as plt
9  | |         plt.plot('data)
10 | |         def foo()
11 | |         plt.show()
12 | |     }
   | |_____^
   |
   = help: message: invalid syntax at inline-python-example/src/main.rs:10:10
```

Though we know the filename, line number and column, we can't easily turn that into a `Span`, so for now it just prints the information in an error message. Would be very cool though if we can get a span to point to the syntax error.

I had to manually expose the `PyMarshal_*` functions, but I'll send those to `pyo3` in a PR too.