### PR TITLE
Put Rust variables in a global RUST variable for python.

### DIFF
--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -221,13 +221,14 @@ impl EmbedPython {
 						} else {
 							unreachable!()
 						};
-						let pyname = format!("_rust_{}", name);
 						let name_str = name.to_string();
-						self.python.push_str(&pyname);
+						self.python.push_str("RUST['");
+						self.python.push_str(&name_str);
+						self.python.push_str("']");
 						self.loc.column += name_str.chars().count() + 1;
-						if self.variable_names.insert(name_str) {
+						if self.variable_names.insert(name_str.clone()) {
 							self.variables.extend(quote! {
-								_python_variables.set_item(#pyname, #name)
+								_python_variables.set_item(#name_str, #name)
 									.expect("Unable to convert variable to Python");
 							});
 						}


### PR DESCRIPTION
This allows the variables to be accessed from inside local function definitions. It also reduces the potential conflict with the python script to a single global variable.

For example:
```rust
fn main() {
  let data = vec![(4, 3), (2, 8), (3, 1), (4, 0)];
  python! {
    import matplotlib.pyplot as plt
    def foo():
      plt.plot('data)
      plt.show()
    foo()
  }
}
```

Without this PR, that results in:
```
Traceback (most recent call last):
  File "inline-python-example/src/main.rs", line 12, in <module>
    foo()
  File "inline-python-example/src/main.rs", line 10, in foo
    plt.plot('data)
NameError: name 'plt' is not defined
thread 'main' panicked at 'python!{...} failed to execute', inline-python-example/src/main.rs:7:2
```

With the PR, it works as expected. Weirdly, it's not complaining about `_rust_data` but about `plt`. Not sure why that happens to be honest. It seems to be "fixed" by passing null as locals to `PyEval_EvalCode`.