### PR TITLE
Shared context

### DIFF
--- a/inline-python-macros/src/embed_python.rs
+++ b/inline-python-macros/src/embed_python.rs
@@ -30,8 +30,7 @@ impl EmbedPython {
 			}
 			let first_indent = *self.first_indent.get_or_insert(loc.column);
 			let indent = loc.column.checked_sub(first_indent);
-			let indent =
-				indent.unwrap_or_else(|| panic!("Invalid indentation on line {}", loc.line));
+			let indent = indent.unwrap_or_else(|| panic!("Invalid indentation on line {}", loc.line));
 			for _ in 0..indent {
 				self.python.push(' ');
 			}

--- a/inline-python-macros/src/embed_python.rs
+++ b/inline-python-macros/src/embed_python.rs
@@ -1,0 +1,121 @@
+use proc_macro2::{Delimiter, LineColumn, Spacing, TokenStream, TokenTree};
+use quote::quote;
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+pub struct EmbedPython {
+	pub python: String,
+	pub variables: TokenStream,
+	pub variable_names: BTreeSet<String>,
+	pub first_indent: Option<usize>,
+	pub loc: LineColumn,
+}
+
+impl EmbedPython {
+	pub fn new() -> Self {
+		Self {
+			python: String::new(),
+			variables: TokenStream::new(),
+			variable_names: BTreeSet::new(),
+			loc: LineColumn { line: 1, column: 0 },
+			first_indent: None,
+		}
+	}
+
+	fn add_whitespace(&mut self, loc: LineColumn) {
+		if loc.line > self.loc.line {
+			while loc.line > self.loc.line {
+				self.python.push('\n');
+				self.loc.line += 1;
+			}
+			let first_indent = *self.first_indent.get_or_insert(loc.column);
+			let indent = loc.column.checked_sub(first_indent);
+			let indent =
+				indent.unwrap_or_else(|| panic!("Invalid indentation on line {}", loc.line));
+			for _ in 0..indent {
+				self.python.push(' ');
+			}
+			self.loc.column = loc.column;
+		} else if loc.line == self.loc.line {
+			while loc.column > self.loc.column {
+				self.python.push(' ');
+				self.loc.column += 1;
+			}
+		}
+	}
+
+	pub fn add(&mut self, input: TokenStream) {
+		let mut tokens = input.into_iter();
+
+		while let Some(token) = tokens.next() {
+			self.add_whitespace(token.span().start());
+
+			match &token {
+				TokenTree::Group(x) => {
+					let (start, end) = match x.delimiter() {
+						Delimiter::Parenthesis => ("(", ")"),
+						Delimiter::Brace => ("{", "}"),
+						Delimiter::Bracket => ("[", "]"),
+						Delimiter::None => ("", ""),
+					};
+					self.python.push_str(start);
+					self.loc.column += start.len();
+					self.add(x.stream());
+					let mut end_loc = token.span().end();
+					end_loc.column = end_loc.column.saturating_sub(end.len());
+					self.add_whitespace(end_loc);
+					self.python.push_str(end);
+					self.loc.column += end.len();
+				}
+				TokenTree::Punct(x) => {
+					if x.as_char() == '\'' && x.spacing() == Spacing::Joint {
+						let name = if let Some(TokenTree::Ident(name)) = tokens.next() {
+							name
+						} else {
+							unreachable!()
+						};
+						let name_str = name.to_string();
+						self.python.push_str("RUST['");
+						self.python.push_str(&name_str);
+						self.python.push_str("']");
+						self.loc.column += name_str.chars().count() + 1;
+						if self.variable_names.insert(name_str.clone()) {
+							self.variables.extend(quote! {
+								_python_variables.set_item(#name_str, #name)
+									.expect("Unable to convert variable to Python");
+							});
+						}
+					} else if x.as_char() == '#' && x.spacing() == Spacing::Joint {
+						// Convert '##' to '//', because otherwise it's
+						// impossible to use the Python operators '//' and '//='.
+						match tokens.next() {
+							Some(TokenTree::Punct(ref p)) if p.as_char() == '#' => {
+								self.python.push_str("//");
+								self.loc.column += 2;
+							}
+							Some(TokenTree::Punct(p)) => {
+								self.python.push(x.as_char());
+								self.python.push(p.as_char());
+								self.loc.column += 2;
+							}
+							_ => {
+								unreachable!();
+							}
+						}
+					} else {
+						self.python.push(x.as_char());
+						self.loc.column += 1;
+					}
+				}
+				TokenTree::Ident(x) => {
+					write!(&mut self.python, "{}", x).unwrap();
+					self.loc = token.span().end();
+				}
+				TokenTree::Literal(x) => {
+					write!(&mut self.python, "{}", x).unwrap();
+					self.loc = token.span().end();
+				}
+			}
+		}
+	}
+}

--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -4,25 +4,19 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream as TokenStream1;
-use proc_macro2::{Delimiter, LineColumn, Spacing, TokenStream, TokenTree};
+use proc_macro2::TokenStream;
 use quote::quote;
-use std::collections::BTreeSet;
-use std::fmt::Write;
 use std::ptr::NonNull;
 use std::os::raw::c_char;
 
 use pyo3::{ffi, AsPyPointer, PyErr, PyObject, Python};
 
+mod embed_python;
+use embed_python::EmbedPython;
+
 #[proc_macro]
 pub fn python(input: TokenStream1) -> TokenStream1 {
-	let mut x = EmbedPython {
-		python: String::new(),
-		variables: TokenStream::new(),
-		variable_names: BTreeSet::new(),
-		loc: LineColumn { line: 1, column: 0 },
-		first_indent: None,
-	};
-
+	let mut x = EmbedPython::new();
 	x.add(TokenStream::from(input.clone()));
 
 	let EmbedPython {
@@ -159,112 +153,5 @@ fn compile_error_msg(py: Python) -> String {
 	match err_value_object(py, value) {
 		None    => kind.as_ref(py).name().into_owned(),
 		Some(x) => python_str(&x),
-	}
-}
-
-struct EmbedPython {
-	python: String,
-	variables: TokenStream,
-	variable_names: BTreeSet<String>,
-	first_indent: Option<usize>,
-	loc: LineColumn,
-}
-
-impl EmbedPython {
-	fn add_whitespace(&mut self, loc: LineColumn) {
-		if loc.line > self.loc.line {
-			while loc.line > self.loc.line {
-				self.python.push('\n');
-				self.loc.line += 1;
-			}
-			let first_indent = *self.first_indent.get_or_insert(loc.column);
-			let indent = loc.column.checked_sub(first_indent);
-			let indent =
-				indent.unwrap_or_else(|| panic!("Invalid indentation on line {}", loc.line));
-			for _ in 0..indent {
-				self.python.push(' ');
-			}
-			self.loc.column = loc.column;
-		} else if loc.line == self.loc.line {
-			while loc.column > self.loc.column {
-				self.python.push(' ');
-				self.loc.column += 1;
-			}
-		}
-	}
-
-	fn add(&mut self, input: TokenStream) {
-		let mut tokens = input.into_iter();
-
-		while let Some(token) = tokens.next() {
-			self.add_whitespace(token.span().start());
-
-			match &token {
-				TokenTree::Group(x) => {
-					let (start, end) = match x.delimiter() {
-						Delimiter::Parenthesis => ("(", ")"),
-						Delimiter::Brace => ("{", "}"),
-						Delimiter::Bracket => ("[", "]"),
-						Delimiter::None => ("", ""),
-					};
-					self.python.push_str(start);
-					self.loc.column += start.len();
-					self.add(x.stream());
-					let mut end_loc = token.span().end();
-					end_loc.column = end_loc.column.saturating_sub(end.len());
-					self.add_whitespace(end_loc);
-					self.python.push_str(end);
-					self.loc.column += end.len();
-				}
-				TokenTree::Punct(x) => {
-					if x.as_char() == '\'' && x.spacing() == Spacing::Joint {
-						let name = if let Some(TokenTree::Ident(name)) = tokens.next() {
-							name
-						} else {
-							unreachable!()
-						};
-						let name_str = name.to_string();
-						self.python.push_str("RUST['");
-						self.python.push_str(&name_str);
-						self.python.push_str("']");
-						self.loc.column += name_str.chars().count() + 1;
-						if self.variable_names.insert(name_str.clone()) {
-							self.variables.extend(quote! {
-								_python_variables.set_item(#name_str, #name)
-									.expect("Unable to convert variable to Python");
-							});
-						}
-					} else if x.as_char() == '#' && x.spacing() == Spacing::Joint {
-						// Convert '##' to '//', because otherwise it's
-						// impossible to use the Python operators '//' and '//='.
-						match tokens.next() {
-							Some(TokenTree::Punct(ref p)) if p.as_char() == '#' => {
-								self.python.push_str("//");
-								self.loc.column += 2;
-							}
-							Some(TokenTree::Punct(p)) => {
-								self.python.push(x.as_char());
-								self.python.push(p.as_char());
-								self.loc.column += 2;
-							}
-							_ => {
-								unreachable!();
-							}
-						}
-					} else {
-						self.python.push(x.as_char());
-						self.loc.column += 1;
-					}
-				}
-				TokenTree::Ident(x) => {
-					write!(&mut self.python, "{}", x).unwrap();
-					self.loc = token.span().end();
-				}
-				TokenTree::Literal(x) => {
-					write!(&mut self.python, "{}", x).unwrap();
-					self.loc = token.span().end();
-				}
-			}
-		}
 	}
 }

--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -55,10 +55,12 @@ pub fn python(input: TokenStream1) -> TokenStream1 {
 	let q = quote! {
 		{
 			let _python_lock = ::inline_python::pyo3::Python::acquire_gil();
+			let _context = ::inline_python::Context::new_with_gil(_python_lock.python()).expect("failed to create python context");
 			let mut _python_variables = ::inline_python::pyo3::types::PyDict::new(_python_lock.python());
 			#variables
 			let r = ::inline_python::run_python_code(
 				_python_lock.python(),
+				&_context,
 				#compiled,
 				Some(_python_variables)
 			);

--- a/inline-python-macros/src/lib.rs
+++ b/inline-python-macros/src/lib.rs
@@ -158,7 +158,7 @@ unsafe fn py_unicode_string(object: *mut ffi::PyObject) -> String {
 	String::from(data)
 }
 
-/// Convert a python object to a string using the the python `str()` function.
+/// Convert a python object to a string using the python `str()` function.
 fn python_str(object: &PyObject) -> String {
 	unsafe {
 		let string = ffi::PyObject_Str(object.as_ptr());

--- a/inline-python-macros/src/meta.rs
+++ b/inline-python-macros/src/meta.rs
@@ -2,7 +2,7 @@ use syn::{
 	bracketed,
 	parse::{Parse, ParseStream},
 	punctuated::Punctuated,
-	token
+	token,
 };
 
 pub struct NameValue {

--- a/inline-python-macros/src/meta.rs
+++ b/inline-python-macros/src/meta.rs
@@ -1,0 +1,55 @@
+use syn::{
+	bracketed,
+	parse::{Parse, ParseStream},
+	punctuated::Punctuated,
+	token
+};
+
+pub struct NameValue {
+	pub name: syn::Ident,
+	pub eq: token::Eq,
+	pub value: syn::Expr,
+}
+
+pub struct Meta {
+	pub pound: token::Pound,
+	pub bang: token::Bang,
+	pub bracket: token::Bracket,
+	pub args: Punctuated<NameValue, token::Comma>,
+}
+
+impl Parse for NameValue {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		Ok(Self {
+			name: input.parse()?,
+			eq: input.parse()?,
+			value: input.parse()?,
+		})
+	}
+}
+
+impl Parse for Meta {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		let content;
+		Ok(Self {
+			pound: input.parse()?,
+			bang: input.parse()?,
+			bracket: bracketed!(content in input),
+			args: Punctuated::parse_terminated(&content)?,
+		})
+	}
+}
+
+impl Meta {
+	pub fn peek(input: ParseStream) -> bool {
+		input.peek(token::Pound) && input.peek2(token::Bang)
+	}
+
+	pub fn maybe_parse(input: ParseStream) -> syn::Result<Option<Self>> {
+		if !Self::peek(input) {
+			Ok(None)
+		} else {
+			Self::parse(input).map(Some)
+		}
+	}
+}

--- a/inline-python/src/lib.rs
+++ b/inline-python/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! # How to use
 //!
-//! Use the `python!{..}` macro to write Python code direcly in your Rust code.
+//! Use the `python!{..}` macro to write Python code directly in your Rust code.
 //! You'll need to add `#![feature(proc_macro_hygiene)]`, and use a nightly
 //! version of the compiler that supports this feature.
 //!
@@ -91,9 +91,9 @@ use pyo3::{
 #[doc(hidden)]
 pub use std::ffi::CStr;
 
-/// An executaion context for Python code.
+/// An execution context for Python code.
 ///
-/// If you pass a manually created to the [`python`] macro, you can share it across invocations.
+/// If you pass a manually created context to the [`python`] macro, you can share it across invocations.
 /// This will keep all global variables and imports intact between macro invocations.
 ///
 /// You may also use it to inspect global variables after the execution of the Python code.
@@ -108,7 +108,7 @@ impl Context {
 	/// If you already have the GIL, use [`new_with_gil`] instead.
 	///
 	/// This function panics if it fails to create the context.
-	/// See [`new_checked`] for a verion that returns a result.
+	/// See [`new_checked`] for a version that returns a result.
 	pub fn new() -> Self {
 		let gil = Python::acquire_gil();
 		let py  = gil.python();
@@ -131,7 +131,7 @@ impl Context {
 		Self::new_with_gil(py)
 	}
 
-	/// Create a new context for runnin Python code.
+	/// Create a new context for running Python code.
 	///
 	/// You must acquire the GIL to call this function.
 	pub fn new_with_gil(py: Python) -> PyResult<Self> {

--- a/inline-python/tests/shared_context.rs
+++ b/inline-python/tests/shared_context.rs
@@ -1,0 +1,30 @@
+#![feature(proc_macro_hygiene)]
+
+use inline_python::{python, pyo3};
+
+#[test]
+fn continue_context() {
+	let context = inline_python::Context::new();
+	python!{
+		#![context = &context]
+		foo = 5
+	}
+	python!{
+		#![context = &context]
+		assert foo == 5
+	}
+}
+
+#[test]
+fn extract_global() {
+	let context = inline_python::Context::new();
+	python!{
+		#![context = &context]
+		foo = 5
+	}
+
+	let gil = pyo3::Python::acquire_gil();
+	let py  = gil.python();
+
+	assert_eq!(context.get_global(py, "foo").unwrap(), Some(5));
+}

--- a/inline-python/tests/shared_context.rs
+++ b/inline-python/tests/shared_context.rs
@@ -1,15 +1,15 @@
 #![feature(proc_macro_hygiene)]
 
-use inline_python::{python, pyo3};
+use inline_python::{pyo3, python};
 
 #[test]
 fn continue_context() {
 	let context = inline_python::Context::new();
-	python!{
+	python! {
 		#![context = &context]
 		foo = 5
 	}
-	python!{
+	python! {
 		#![context = &context]
 		assert foo == 5
 	}
@@ -18,13 +18,13 @@ fn continue_context() {
 #[test]
 fn extract_global() {
 	let context = inline_python::Context::new();
-	python!{
+	python! {
 		#![context = &context]
 		foo = 5
 	}
 
 	let gil = pyo3::Python::acquire_gil();
-	let py  = gil.python();
+	let py = gil.python();
 
 	assert_eq!(context.get_global(py, "foo").unwrap(), Some(5));
 }


### PR DESCRIPTION
This PR allows the user to pass in a pre-made context for the python code to run in through an attribute at the top of the python code. The context can then be re-used multiple times for different calls to `python!{...}`.

As an example, this now works with the PR:
```rust
#![feature(proc_macro_hygiene)]

use inline_python::python;

fn main() {
	let data = vec![(4, 3), (2, 8), (3, 1), (4, 0)];
	let context = inline_python::Context::new();
	python! {
		#![context = &context]
		import matplotlib.pyplot as plt
		plt.plot('data)
	}
	python! {
		#![context = &context]
		plt.show()
	}
}
```

I'm pretty sure it also allows the python code to set global variables that can be read back by Rust again. Though currently, that would require the user to manually take the GIL.