### PR TITLE
Compile errors

### DIFF
--- a/inline-python-macros/src/embed_python.rs
+++ b/inline-python-macros/src/embed_python.rs
@@ -30,7 +30,7 @@ impl EmbedPython {
 			}
 			let first_indent = *self.first_indent.get_or_insert(loc.column);
 			let indent = loc.column.checked_sub(first_indent);
-			let indent = indent.ok_or_else(|| syn::Error::new(span, format!("Invalid indentation on line {}", loc.line)))?;
+			let indent = indent.ok_or_else(|| error!(span, "Invalid indentation on line {}", loc.line))?;
 			for _ in 0..indent {
 				self.python.push(' ');
 			}


### PR DESCRIPTION
This PR turns all compile-time panics into compilation errors. It also sets the span for python syntax errors to the matching tokens (currently the whole line causing the syntax error).

For example:
```rust
python! {
  def foo:
    return 5
}
```

Now generates this:
```
error: python: invalid syntax
 --> inline-python-example/src/main.rs:8:3
  |
8 |         def foo:
  |         ^^^^^^^^
```